### PR TITLE
Fix typo in variable name

### DIFF
--- a/app/Http/Controllers/StoryController.php
+++ b/app/Http/Controllers/StoryController.php
@@ -180,7 +180,7 @@ class StoryController extends Controller
      * @param  \App\Story  $story
      * @return \Illuminate\Http\Response
      */
-    public function destroy($patienId, $storyId)
+    public function destroy($patientId, $storyId)
     {
         if (Story::destroy($storyId)) {
             return response()->success([], 200, 'OK');


### PR DESCRIPTION
$patientId in the destroy method was spelled incorrectly. It's unused, but we'll discuss that soon.